### PR TITLE
use_ssh_routes and use_tcp_routes and use_route53

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ You should fill in the stub values with the correct content.
 
 ```hcl
 env_name              = "some-environment-name"
-access_key            = "access-key-id"
-secret_key            = "secret-access-key"
 region                = "us-west-1"
 availability_zones    = ["us-west-1a", "us-west-1c"]
 ops_manager_ami       = "ami-4f291f2f"
@@ -85,6 +83,8 @@ rds_instance_count    = 1
 dns_suffix            = "example.com"
 vpc_cidr              = "10.0.0.0/16"
 use_route53           = true
+use_ssh_routes        = true
+use_tcp_routes        = true
 internet_gateway_id   = "igw-askdjlkas"
 vpc_id                = "ID of the targeted pre-existing VPC"
 ops_manager_role_name = "name to be given to the ops manager role, or the name of the existing role to use therein."

--- a/modules/control_plane/dns.tf
+++ b/modules/control_plane/dns.tf
@@ -1,8 +1,7 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "control_plane" {
+
+  count   = "${var.use_route53}"
+
   zone_id = "${var.zone_id}"
   name    = "plane.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"

--- a/modules/control_plane/outputs.tf
+++ b/modules/control_plane/outputs.tf
@@ -1,5 +1,5 @@
 output "domain" {
-  value = "${aws_route53_record.control_plane.name}"
+  value = "${aws_route53_record.control_plane.*.name}"
 }
 
 output "lb_target_groups" {

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -18,6 +18,9 @@ variable "region" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "zone_id" {
   type = "string"
 }

--- a/modules/infra/dns.tf
+++ b/modules/infra/dns.tf
@@ -7,18 +7,16 @@ locals {
   resource_dns_name_servers = "${join(",", flatten(concat(aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
   name_servers              = "${var.hosted_zone == "" ? local.resource_dns_name_servers : local.data_dns_name_servers}"
   hosted_zone_count         = "${var.hosted_zone == "" ? 0 : 1}"
-
-  use_route53 = "${var.use_route53 == true ? 1 : 0}"
 }
 
 data "aws_route53_zone" "pcf_zone" {
-  count = "${local.use_route53 ? local.hosted_zone_count : 0}"
+  count = "${var.use_route53 ? local.hosted_zone_count : 0}"
 
   name = "${var.hosted_zone}"
 }
 
 resource "aws_route53_zone" "pcf_zone" {
-  count = "${local.use_route53 ? (1 - local.hosted_zone_count) : 0}"
+  count = "${var.use_route53 ? (1 - local.hosted_zone_count) : 0}"
 
   name = "${var.env_name}.${var.dns_suffix}"
 
@@ -26,7 +24,7 @@ resource "aws_route53_zone" "pcf_zone" {
 }
 
 resource "aws_route53_record" "name_servers" {
-  count = "${local.use_route53 ? (1 - local.hosted_zone_count) : 0}"
+  count = "${var.use_route53 ? (1 - local.hosted_zone_count) : 0}"
 
   zone_id = "${local.zone_id}"
   name    = "${var.env_name}.${var.dns_suffix}"

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -56,8 +56,6 @@ variable "nat_ami_map" {
 }
 
 variable "use_route53" {
-  default = true
-  description = "Indicate whether or not to enabled route53"
 }
 
 variable "internet_gateway_id" {

--- a/modules/ops_manager/dns.tf
+++ b/modules/ops_manager/dns.tf
@@ -1,13 +1,9 @@
-locals {
-  use_route53 = "${var.use_route53 == true ? 1 : 0}"
-}
-
 resource "aws_route53_record" "ops_manager_attached_eip" {
   name    = "pcf.${var.env_name}.${var.dns_suffix}"
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 ? var.vm_count : 0}"
+  count   = "${var.use_route53 ? var.vm_count : 0}"
 
   records = ["${coalesce(join("", aws_eip.ops_manager_attached.*.public_ip), aws_instance.ops_manager.private_ip)}"]
 }
@@ -17,7 +13,7 @@ resource "aws_route53_record" "ops_manager_unattached_eip" {
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 && (var.vm_count < 1) ? 1 : 0}"
+  count   = "${var.use_route53 && (var.vm_count < 1) ? 1 : 0}"
 
   records = ["${aws_eip.ops_manager_unattached.*.public_ip}"]
 }
@@ -27,7 +23,7 @@ resource "aws_route53_record" "optional_ops_manager" {
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 ? var.optional_count : 0}"
+  count   = "${var.use_route53 ? var.optional_count : 0}"
 
   records = ["${coalesce(join("", aws_eip.optional_ops_manager.*.public_ip), aws_instance.optional_ops_manager.private_ip)}"]
 }

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -37,9 +37,6 @@ variable "tags" {
   type = "map"
 }
 
-variable "use_route53" {
-  default = true
-  description = "Indicate whether or not to enabled route53"
-}
+variable "use_route53" {}
 
 variable "ops_manager_role_name" {}

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "wildcard_apps_dns" {
 }
 
 resource "aws_route53_record" "ssh" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${local.use_route53  && var.use_ssh_routes? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "ssh.sys.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -1,9 +1,5 @@
-locals {
-  use_route53 = "${var.use_route53 == true ? 1 : 0}"
-}
-
 resource "aws_route53_record" "wildcard_sys_dns" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "*.sys.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"
@@ -13,7 +9,7 @@ resource "aws_route53_record" "wildcard_sys_dns" {
 }
 
 resource "aws_route53_record" "wildcard_apps_dns" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "*.apps.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"
@@ -23,7 +19,7 @@ resource "aws_route53_record" "wildcard_apps_dns" {
 }
 
 resource "aws_route53_record" "ssh" {
-  count   = "${local.use_route53  && var.use_ssh_routes? 1 : 0}"
+  count   = "${var.use_route53 && var.use_ssh_routes? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "ssh.sys.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -1,6 +1,5 @@
 locals {
   use_route53 = "${var.use_route53 == true ? 1 : 0}"
-
 }
 
 resource "aws_route53_record" "wildcard_sys_dns" {
@@ -34,7 +33,7 @@ resource "aws_route53_record" "ssh" {
 }
 
 resource "aws_route53_record" "tcp" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53 && var.use_tcp_routes ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "tcp.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"

--- a/modules/pas/lbs.tf
+++ b/modules/pas/lbs.tf
@@ -84,6 +84,9 @@ resource "aws_lb_target_group" "web_443" {
 # SSH Load Balancer
 
 resource "aws_security_group" "ssh_lb" {
+
+  count = "${var.use_ssh_routes}"
+
   name        = "ssh_lb_security_group"
   description = "Load Balancer SSH Security Group"
   vpc_id      = "${var.vpc_id}"
@@ -106,6 +109,9 @@ resource "aws_security_group" "ssh_lb" {
 }
 
 resource "aws_lb" "ssh" {
+
+  count = "${var.use_ssh_routes}"
+
   name                             = "${var.env_name}-ssh-lb"
   load_balancer_type               = "network"
   enable_cross_zone_load_balancing = true
@@ -114,6 +120,9 @@ resource "aws_lb" "ssh" {
 }
 
 resource "aws_lb_listener" "ssh" {
+
+  count = "${var.use_ssh_routes}"
+
   load_balancer_arn = "${aws_lb.ssh.arn}"
   port              = 2222
   protocol          = "TCP"
@@ -125,6 +134,9 @@ resource "aws_lb_listener" "ssh" {
 }
 
 resource "aws_lb_target_group" "ssh" {
+
+  count = "${var.use_ssh_routes}"
+
   name     = "${var.env_name}-ssh-tg"
   port     = 2222
   protocol = "TCP"

--- a/modules/pas/lbs.tf
+++ b/modules/pas/lbs.tf
@@ -138,10 +138,13 @@ resource "aws_lb_target_group" "ssh" {
 # TCP Load Balancer
 
 locals {
-  tcp_port_count = 10
+  tcp_port_count = "${var.use_tcp_routes ? 10 : 0}"
 }
 
 resource "aws_security_group" "tcp_lb" {
+
+  count = "${var.use_tcp_routes}"
+
   name        = "tcp_lb_security_group"
   description = "Load Balancer TCP Security Group"
   vpc_id      = "${var.vpc_id}"
@@ -164,6 +167,9 @@ resource "aws_security_group" "tcp_lb" {
 }
 
 resource "aws_lb" "tcp" {
+
+  count = "${var.use_tcp_routes}"
+
   name                             = "${var.env_name}-tcp-lb"
   load_balancer_type               = "network"
   enable_cross_zone_load_balancing = true
@@ -172,6 +178,7 @@ resource "aws_lb" "tcp" {
 }
 
 resource "aws_lb_listener" "tcp" {
+
   load_balancer_arn = "${aws_lb.tcp.arn}"
   port              = "${1024 + count.index}"
   protocol          = "TCP"

--- a/modules/pas/outputs.tf
+++ b/modules/pas/outputs.tf
@@ -88,7 +88,7 @@ output "tcp_target_groups" {
 }
 
 output "ssh_target_groups" {
-  value = ["${aws_lb_target_group.ssh.name}"]
+  value = ["${aws_lb_target_group.ssh.*.name}"]
 }
 
 output "isoseg_target_groups" {

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -64,9 +64,8 @@ variable "tags" {
   type = "map"
 }
 variable "use_route53" {
-  default = true
-  description = "Indicate whether or not to enabled route53"
 }
+
 locals {
   pas_cidr      = "${cidrsubnet(var.vpc_cidr, 6, 1)}"
   services_cidr = "${cidrsubnet(var.vpc_cidr, 6, 2)}"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -20,6 +20,8 @@ variable "vpc_id" {
 
 variable "use_tcp_routes" {}
 
+variable "use_ssh_routes" {}
+
 variable "route_table_ids" {
   type = "list"
 }

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -18,6 +18,8 @@ variable "vpc_id" {
   type = "string"
 }
 
+variable "use_tcp_routes" {}
+
 variable "route_table_ids" {
   type = "list"
 }

--- a/modules/pks/dns.tf
+++ b/modules/pks/dns.tf
@@ -1,7 +1,3 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "pks_api_dns" {
   zone_id = "${var.zone_id}"
   name    = "api.pks.${var.env_name}.${var.dns_suffix}"
@@ -13,5 +9,5 @@ resource "aws_route53_record" "pks_api_dns" {
     evaluate_target_health = true
   }
 
-  count = "${local.use_route53 ? 1 : 0}"
+  count = "${var.use_route53}"
 }

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -34,6 +34,9 @@ variable "dns_suffix" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "tags" {
   type = "map"
 }

--- a/modules/rds/template.tf
+++ b/modules/rds/template.tf
@@ -42,6 +42,8 @@ resource "aws_security_group" "rds_security_group" {
 }
 
 resource "random_string" "rds_password" {
+  count = "${var.rds_instance_count > 0 ? 1 : 0}"
+
   length  = 16
   special = false
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -1,7 +1,6 @@
 provider "aws" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version =  "< 2.0.0"
 }
 
 terraform {
@@ -20,9 +19,12 @@ module "infra" {
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
   vpc_cidr           = "${var.vpc_cidr}"
+  vpc_id             = "${var.vpc_id}"
+  internet_gateway_id = "${var.internet_gateway_id}"
 
   hosted_zone = "${var.hosted_zone}"
   dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   internetless = false
   tags         = "${local.actual_tags}"
@@ -43,8 +45,12 @@ module "ops_manager" {
   private       = "${var.ops_manager_private}"
   vpc_id        = "${module.infra.vpc_id}"
   vpc_cidr      = "${var.vpc_cidr}"
+
+  use_route53   = "${var.use_route53}"
   dns_suffix    = "${var.dns_suffix}"
   zone_id       = "${module.infra.zone_id}"
+
+  ops_manager_role_name = "${var.ops_manager_role_name}"
 
   # additional_iam_roles_arn = ["${module.pas.iam_pas_bucket_role_arn}"]
   bucket_suffix = "${local.bucket_suffix}"
@@ -62,6 +68,8 @@ module "control_plane" {
   private_route_table_ids = "${module.infra.deployment_route_table_ids}"
   tags                    = "${local.actual_tags}"
   region                  = "${var.region}"
+
+  use_route53             = "${var.use_route53}"
   dns_suffix              = "${var.dns_suffix}"
   zone_id                 = "${module.infra.zone_id}"
 }

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -1,12 +1,24 @@
 variable "env_name" {}
 
 variable "dns_suffix" {}
-variable "access_key" {}
-variable "secret_key" {}
+
 variable "region" {}
+
+variable "use_route53" {
+  default = true
+  description = "Indicate whether or not to enable route53"
+}
 
 variable "availability_zones" {
   type = "list"
+}
+
+variable "vpc_id" {
+  description = "pre-exsting VPC ID"
+}
+
+variable "internet_gateway_id" {
+  description = "pre-exsting IGW ID"
 }
 
 variable "vpc_cidr" {
@@ -21,6 +33,7 @@ variable "hosted_zone" {
 /**************
 * Ops Manager *
 ***************/
+
 variable "ops_manager_ami" {
   default = ""
 }
@@ -44,6 +57,11 @@ variable "ops_manager_vm" {
 
 variable "optional_ops_manager" {
   default = false
+}
+
+variable ops_manager_role_name {
+  default = "Director"
+  description = "the role name used for the ops man controlled bosh director"
 }
 
 /******

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -121,6 +121,7 @@ module "pas" {
   tags = "${local.actual_tags}"
   use_route53 = "${var.use_route53}"
   use_tcp_routes = "${var.use_tcp_routes}"
+  use_ssh_routes = "${var.use_ssh_routes}"
 }
 
 module "rds" {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region     = "${var.region}"
+  version =  "< 2.0.0"
 }
 
 terraform {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -120,6 +120,7 @@ module "pas" {
 
   tags = "${local.actual_tags}"
   use_route53 = "${var.use_route53}"
+  use_tcp_routes = "${var.use_tcp_routes}"
 }
 
 module "rds" {

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -7,7 +7,12 @@ variable "use_route53" {
 
 variable "use_tcp_routes" {
   default = true
-  description = "Indicate whether or not to enable tcp routes and lbs"
+  description = "Indicate whether or not to enable tcp routes and elbs"
+}
+
+variable "use_ssh_routes" {
+  default = true
+  description = "Indicate whether or not to enable ssh routes and elbs"
 }
 
 variable "dns_suffix" {}

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -39,6 +39,7 @@ variable "internet_gateway_id" {
 variable "vpc_id" {
   description = "pre-exsting VPC ID"
 }
+
 /******
 * PAS *
 *******/

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -2,7 +2,12 @@ variable "env_name" {}
 
 variable "use_route53" {
   default = true
-  description = "Indicate whether or not to enabled route53"
+  description = "Indicate whether or not to enable route53"
+}
+
+variable "use_tcp_routes" {
+  default = true
+  description = "Indicate whether or not to enable tcp routes and lbs"
 }
 
 variable "dns_suffix" {}

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -1,7 +1,6 @@
 provider "aws" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version =  "< 2.0.0"
 }
 
 terraform {
@@ -29,14 +28,18 @@ resource "random_integer" "bucket" {
 module "infra" {
   source = "../modules/infra"
 
-  region             = "${var.region}"
-  env_name           = "${var.env_name}"
-  availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
-  internetless       = false
+  region              = "${var.region}"
+  env_name            = "${var.env_name}"
+  availability_zones  = "${var.availability_zones}"
+  vpc_id              = "${var.vpc_id}"
+  vpc_cidr            = "${var.vpc_cidr}"
+  internet_gateway_id = "${var.internet_gateway_id}"
+  internetless        = false
 
   hosted_zone = "${var.hosted_zone}"
   dns_suffix  = "${var.dns_suffix}"
+
+  use_route53 = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }
@@ -60,6 +63,9 @@ module "ops_manager" {
   zone_id                  = "${module.infra.zone_id}"
   bucket_suffix            = "${local.bucket_suffix}"
   additional_iam_roles_arn = ["${module.pks.pks_worker_iam_role_arn}", "${module.pks.pks_master_iam_role_arn}"]
+
+  ops_manager_role_name    = "${var.ops_manager_role_name}"
+  use_route53              = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }
@@ -88,8 +94,9 @@ module "pks" {
   private_route_table_ids = "${module.infra.deployment_route_table_ids}"
   public_subnet_ids       = "${module.infra.public_subnet_ids}"
 
-  zone_id    = "${module.infra.zone_id}"
-  dns_suffix = "${var.dns_suffix}"
+  zone_id     = "${module.infra.zone_id}"
+  dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -6,19 +6,28 @@ variable "hosted_zone" {
   default = ""
 }
 
-variable "access_key" {}
-
-variable "secret_key" {}
-
 variable "region" {}
 
 variable "availability_zones" {
   type = "list"
 }
 
+variable "vpc_id" {
+  description = "pre-exsting VPC ID"
+}
+
 variable "vpc_cidr" {
   type    = "string"
   default = "10.0.0.0/16"
+}
+
+variable "internet_gateway_id" {
+  description = "pre-exsting IGW ID"
+}
+
+variable "use_route53" {
+  default = true
+  description = "Indicate whether or not to enable route53"
 }
 
 /****************
@@ -50,10 +59,6 @@ variable "optional_ops_manager" {
   default = false
 }
 
-/*******************
-* SSL Certificates *
-********************/
-
 variable "ssl_cert" {
   type        = "string"
   description = "the contents of an SSL certificate to be used by the PKS API, optional if `ssl_ca_cert` is provided"
@@ -78,6 +83,11 @@ variable "ssl_ca_private_key" {
   default     = ""
 }
 
+variable ops_manager_role_name {
+  default = "Director"
+  description = "the role name used for the ops man controlled bosh director"
+}
+
 /******
 * RDS *
 *******/
@@ -94,10 +104,6 @@ variable "rds_instance_count" {
   type    = "string"
   default = 0
 }
-
-/*******
-* Tags *
-********/
 
 variable "tags" {
   type        = "map"


### PR DESCRIPTION
these are all tied together, otherwise this would be 3 PRs... boolean logic was messed up in our fork so fixing that in general, and adding the ability to turn ssh routing, tcp routing and route53 on and off.