### PR TITLE
Store state in s3

### DIFF
--- a/env/dev/ssh/README.md
+++ b/env/dev/ssh/README.md
@@ -1,0 +1,14 @@
+# terraforming-aws example
+
+This is an example template that can be used to manage an environment (in this case, a dev environment that we've named "ssh".)
+
+The intention is to allow users to check the "main.tf" file into source control. The template includes information on where to store the state remotely, and replaces the terraform.tfvars file.
+
+Because the configuration is contained withing the example "main.tf" file it is possible to manage existing infra on day 2 without needing to re-establish a potentially unknown initial configuration.
+
+Note that this template does not have the usual outputs, as it assumed that the user will get them via interrogating the remote state file instead. To access the outputs in a the classic manner, use the following:
+
+```bash
+terraform output -module=pas
+```
+

--- a/env/dev/ssh/main.tf
+++ b/env/dev/ssh/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = "< 0.12.0"
+
+  backend "s3" {
+    bucket = "eagle-state"
+    key    = "dev/ssh/terraform.tfstate"
+    encrypt = true
+    kms_key_id = "7a0c75b1-b2e1-490d-8519-0aa44f1ba647"
+    dynamodb_table = "state_lock"
+  }
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  version = "~> 1.60"
+}
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.2"
+}
+
+module "pas" {
+  source              = "../../../terraforming-pas"
+  availability_zones  = ["us-east-1a", "us-east-1b"]
+  dns_suffix          = "jgordon.xyz"
+  env_name            = "ssh"
+  rds_instance_count  = 0
+  use_route53           = false
+  use_tcp_routes        = false
+  use_ssh_routes        = false
+  internet_gateway_id   = "igw-031c26ac18e580e2a"
+  vpc_id                = "vpc-053b17e24125579d5"
+  ops_manager_role_name = "DIRECTOR"
+  ops_manager_ami       = "ami-0b4e720c1858f1786"
+}

--- a/modules/calculate_subnets/main.tf
+++ b/modules/calculate_subnets/main.tf
@@ -1,6 +1,4 @@
-variable "vpc_cidr" {
-  default = "10.0.0.0/16"
-}
+variable "vpc_cidr" {}
 
 locals {
   cidr_split= "${split("/", var.vpc_cidr)}"

--- a/modules/control_plane/network.tf
+++ b/modules/control_plane/network.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_subnet" "control_plane" {
   count             = "${length(var.availability_zones)}"
   cidr_block        = "${cidrsubnet(local.control_plane_cidr, 4, count.index)}"

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -10,14 +10,6 @@ variable "availability_zones" {
   type = "list"
 }
 
-variable "vpc_cidr" {
-  type = "string"
-}
-
-variable "region" {
-  type = "string"
-}
-
 variable "zone_id" {
   type = "string"
 }
@@ -43,7 +35,7 @@ variable "tags" {
 
 module "cidr_lookup" {
   source = "../calculate_subnets"
-  vpc_cidr = "${var.vpc_cidr}"
+  vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
 }
 
 locals {

--- a/modules/dynamo/main.tf
+++ b/modules/dynamo/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = "< 0.12.0"
+}
+
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name           = "state_lock"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Eagle-state"
+    Environment = "ssh"
+  }
+}

--- a/modules/infra/nat.tf
+++ b/modules/infra/nat.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "nat_security_group" {
   vpc_id      = "${data.aws_vpc.vpc.id}"
 
   ingress {
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -2,10 +2,6 @@ variable "env_name" {
   type = "string"
 }
 
-variable "region" {
-  type = "string"
-}
-
 variable "hosted_zone" {
   type    = "string"
   default = ""

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -18,11 +18,6 @@ variable "availability_zones" {
   type = "list"
 }
 
-variable "vpc_cidr" {
-  type    = "string"
-  default = "10.0.0.0/16"
-}
-
 variable "tags" {
   type        = "map"
   default     = {}
@@ -64,7 +59,7 @@ variable "vpc_id" {
 
 module "cidr_lookup" {
   source = "../calculate_subnets"
-  vpc_cidr = "${var.vpc_cidr}"
+  vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
 }
 
 locals {

--- a/modules/infra/vpc.tf
+++ b/modules/infra/vpc.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "vms_security_group" {
   vpc_id      = "${data.aws_vpc.vpc.id}"
 
   ingress {
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/modules/infra/vpc.tf
+++ b/modules/infra/vpc.tf
@@ -24,9 +24,11 @@ resource "aws_security_group" "vms_security_group" {
   tags = "${merge(var.tags, map("Name", "${var.env_name}-vms-security-group"))}"
 }
 
+data "aws_region" "current" {}
+
 locals {
-  ec2_address = "com.amazonaws.${var.region}.ec2"
-  lb_api_address = "com.amazonaws.${var.region}.elasticloadbalancing"
+  ec2_address = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  lb_api_address = "com.amazonaws.${data.aws_region.current.name}.elasticloadbalancing"
 }
 
 resource "aws_vpc_endpoint" "ec2" {

--- a/modules/ops_manager/security_group.tf
+++ b/modules/ops_manager/security_group.tf
@@ -1,31 +1,35 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_security_group" "ops_manager_security_group" {
   name        = "ops_manager_security_group"
   description = "Ops Manager Security Group"
   vpc_id      = "${var.vpc_id}"
 
   ingress {
-    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? data.aws_vpc.vpc.cidr_block : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
   }
 
   ingress {
-    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? data.aws_vpc.vpc.cidr_block : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
   }
 
   ingress {
-    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? data.aws_vpc.vpc.cidr_block : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
   }
 
   egress {
-    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? data.aws_vpc.vpc.cidr_block : "0.0.0.0/0"}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -16,8 +16,6 @@ variable "subnet_id" {}
 
 variable "vpc_id" {}
 
-variable "vpc_cidr" {}
-
 variable "additional_iam_roles_arn" {
   type    = "list"
   default = []

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -1,7 +1,3 @@
-variable "region" {
-  type = "string"
-}
-
 variable "optional_count" {}
 
 variable "vm_count" {}

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_subnet" "pas_subnets" {
   count             = "${length(var.availability_zones)}"
   vpc_id            = "${var.vpc_id}"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -2,10 +2,6 @@ variable "env_name" {
   type = "string"
 }
 
-variable "region" {
-  type = "string"
-}
-
 variable "availability_zones" {
   type = "list"
 }

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -6,10 +6,6 @@ variable "availability_zones" {
   type = "list"
 }
 
-variable "vpc_cidr" {
-  type = "string"
-}
-
 variable "vpc_id" {
   type = "string"
 }
@@ -69,7 +65,7 @@ variable "tags" {
 
 module "cidr_lookup" {
   source = "../calculate_subnets"
-  vpc_cidr = "${var.vpc_cidr}"
+  vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
 }
 
 locals {

--- a/modules/pks/networking.tf
+++ b/modules/pks/networking.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_subnet" "pks_subnets" {
   count             = "${length(var.availability_zones)}"
   vpc_id            = "${var.vpc_id}"

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -2,10 +2,6 @@ variable "env_name" {
   type = "string"
 }
 
-variable "region" {
-  type = "string"
-}
-
 variable "availability_zones" {
   type = "list"
 }

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 
 module "cidr_lookup" {
   source = "../calculate_subnets"
-  vpc_cidr = "${var.vpc_cidr}"
+  vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
 }
 
 locals {

--- a/modules/rds/template.tf
+++ b/modules/rds/template.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_subnet" "rds_subnets" {
   count             = "${var.rds_instance_count > 0 ? length(var.availability_zones) : 0}"
   vpc_id            = "${var.vpc_id}"
@@ -24,14 +28,14 @@ resource "aws_security_group" "rds_security_group" {
   vpc_id      = "${var.vpc_id}"
 
   ingress {
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
     protocol    = "tcp"
     from_port   = "${var.db_port}"
     to_port     = "${var.db_port}"
   }
 
   egress {
-    cidr_blocks = ["${var.vpc_cidr}"]
+    cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -29,10 +29,6 @@ variable "availability_zones" {
   type = "list"
 }
 
-variable "vpc_cidr" {
-  type = "string"
-}
-
 variable "vpc_id" {
   type = "string"
 }
@@ -43,7 +39,7 @@ variable "tags" {
 
 module "cidr_lookup" {
   source = "../calculate_subnets"
-  vpc_cidr = "${var.vpc_cidr}"
+  vpc_cidr = "${data.aws_vpc.vpc.cidr_block}"
 }
 
 locals {

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -27,10 +27,8 @@ resource "random_integer" "bucket" {
 module "infra" {
   source = "../modules/infra"
 
-  region             = "${var.region}"
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${var.vpc_id}"
   internet_gateway_id = "${var.internet_gateway_id}"
 
@@ -50,13 +48,11 @@ module "ops_manager" {
   subnet_id      = "${local.ops_man_subnet_id}"
 
   env_name      = "${var.env_name}"
-  region        = "${var.region}"
   ami           = "${var.ops_manager_ami}"
   optional_ami  = "${var.optional_ops_manager_ami}"
   instance_type = "${var.ops_manager_instance_type}"
   private       = "${var.ops_manager_private}"
   vpc_id        = "${module.infra.vpc_id}"
-  vpc_cidr      = "${var.vpc_cidr}"
 
   dns_suffix    = "${var.dns_suffix}"
   zone_id       = "${module.infra.zone_id}"
@@ -75,11 +71,9 @@ module "control_plane" {
   vpc_id                  = "${module.infra.vpc_id}"
   env_name                = "${var.env_name}"
   availability_zones      = "${var.availability_zones}"
-  vpc_cidr                = "${var.vpc_cidr}"
   public_subnet_ids       = "${module.infra.public_subnet_ids}"
   private_route_table_ids = "${module.infra.deployment_route_table_ids}"
   tags                    = "${local.actual_tags}"
-  region                  = "${var.region}"
 
   dns_suffix              = "${var.dns_suffix}"
   zone_id                 = "${module.infra.zone_id}"
@@ -99,7 +93,6 @@ module "rds" {
 
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${module.infra.vpc_id}"
 
   tags = "${local.actual_tags}"

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -1,5 +1,7 @@
 variable "env_name" {}
 
+variable "region" {}
+
 variable "dns_suffix" {}
 
 variable "availability_zones" {

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -2,8 +2,6 @@ variable "env_name" {}
 
 variable "dns_suffix" {}
 
-variable "region" {}
-
 variable "availability_zones" {
   type = "list"
 }

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -1,33 +1,3 @@
-provider "aws" {
-  region     = "${var.region}"
-  version = "~> 1.60"
-}
-
-terraform {
-  required_version = "< 0.12.0"
-
-  backend "s3" {
-    bucket = "eagle-state"
-    key    = "dev/terraform.tfstate"
-    region = "us-east-1"
-    encrypt = true
-    kms_key_id = "7a0c75b1-b2e1-490d-8519-0aa44f1ba647"
-    dynamodb_table = "state_lock"
-  }
-}
-
-provider "random" {
-  version = "~> 2.0"
-}
-
-provider "template" {
-  version = "~> 1.0"
-}
-
-provider "tls" {
-  version = "~> 1.2"
-}
-
 locals {
   ops_man_subnet_id = "${var.ops_manager_private ? element(module.infra.infrastructure_subnet_ids, 0) : element(module.infra.public_subnet_ids, 0)}"
 
@@ -49,7 +19,6 @@ resource "random_integer" "bucket" {
 module "infra" {
   source = "../modules/infra"
 
-  region             = "${var.region}"
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
   vpc_cidr           = "${var.vpc_cidr}"
@@ -73,7 +42,6 @@ module "ops_manager" {
   subnet_id      = "${local.ops_man_subnet_id}"
 
   env_name                 = "${var.env_name}"
-  region                   = "${var.region}"
   ami                      = "${var.ops_manager_ami}"
   optional_ami             = "${var.optional_ops_manager_ami}"
   instance_type            = "${var.ops_manager_instance_type}"
@@ -121,7 +89,6 @@ module "pas" {
   source = "../modules/pas"
 
   env_name           = "${var.env_name}"
-  region             = "${var.region}"
   availability_zones = "${var.availability_zones}"
   vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${module.infra.vpc_id}"

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -21,7 +21,6 @@ module "infra" {
 
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
 
   internetless = "${var.internetless}"
 
@@ -47,7 +46,6 @@ module "ops_manager" {
   instance_type            = "${var.ops_manager_instance_type}"
   private                  = "${var.ops_manager_private}"
   vpc_id                   = "${module.infra.vpc_id}"
-  vpc_cidr                 = "${var.vpc_cidr}"
   dns_suffix               = "${var.dns_suffix}"
   zone_id                  = "${module.infra.zone_id}"
   additional_iam_roles_arn = ["${module.pas.iam_pas_bucket_role_arn}"]
@@ -90,7 +88,6 @@ module "pas" {
 
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${module.infra.vpc_id}"
   route_table_ids    = "${module.infra.deployment_route_table_ids}"
   public_subnet_ids  = "${module.infra.public_subnet_ids}"
@@ -127,7 +124,6 @@ module "rds" {
 
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${module.infra.vpc_id}"
   tags               = "${local.actual_tags}"
 }

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -5,6 +5,15 @@ provider "aws" {
 
 terraform {
   required_version = "< 0.12.0"
+
+  backend "s3" {
+    bucket = "eagle-state"
+    key    = "dev/terraform.tfstate"
+    region = "us-east-1"
+    encrypt = true
+    kms_key_id = "7a0c75b1-b2e1-490d-8519-0aa44f1ba647"
+    dynamodb_table = "state_lock"
+  }
 }
 
 provider "random" {

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -212,10 +212,6 @@ output "ops_manager_ssh_public_key" {
   value = "${module.ops_manager.ssh_public_key}"
 }
 
-output "region" {
-  value = "${var.region}"
-}
-
 output "azs" {
   value = "${var.availability_zones}"
 }

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -16,8 +16,6 @@ variable "hosted_zone" {
   default = ""
 }
 
-variable "region" {}
-
 variable "availability_zones" {
   type = "list"
 }

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -40,11 +40,9 @@ resource "random_integer" "bucket" {
 module "infra" {
   source = "../modules/infra"
 
-  region              = "${var.region}"
   env_name            = "${var.env_name}"
   availability_zones  = "${var.availability_zones}"
   vpc_id              = "${var.vpc_id}"
-  vpc_cidr            = "${var.vpc_cidr}"
   internet_gateway_id = "${var.internet_gateway_id}"
   internetless        = false
 
@@ -63,13 +61,11 @@ module "ops_manager" {
   subnet_id      = "${local.ops_man_subnet_id}"
 
   env_name                 = "${var.env_name}"
-  region                   = "${var.region}"
   ami                      = "${var.ops_manager_ami}"
   optional_ami             = "${var.optional_ops_manager_ami}"
   instance_type            = "${var.ops_manager_instance_type}"
   private                  = "${var.ops_manager_private}"
   vpc_id                   = "${module.infra.vpc_id}"
-  vpc_cidr                 = "${var.vpc_cidr}"
   dns_suffix               = "${var.dns_suffix}"
   zone_id                  = "${module.infra.zone_id}"
   use_route53              = "${var.use_route53}"
@@ -98,9 +94,7 @@ module "pks" {
   source = "../modules/pks"
 
   env_name                = "${var.env_name}"
-  region                  = "${var.region}"
   availability_zones      = "${var.availability_zones}"
-  vpc_cidr                = "${var.vpc_cidr}"
   vpc_id                  = "${module.infra.vpc_id}"
   private_route_table_ids = "${module.infra.deployment_route_table_ids}"
   public_subnet_ids       = "${module.infra.public_subnet_ids}"
@@ -125,7 +119,6 @@ module "rds" {
 
   env_name           = "${var.env_name}"
   availability_zones = "${var.availability_zones}"
-  vpc_cidr           = "${var.vpc_cidr}"
   vpc_id             = "${module.infra.vpc_id}"
 
   tags = "${local.actual_tags}"

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -1,5 +1,7 @@
 variable "env_name" {}
 
+variable "region" {}
+
 variable "dns_suffix" {}
 
 variable "hosted_zone" {

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -6,8 +6,6 @@ variable "hosted_zone" {
   default = ""
 }
 
-variable "region" {}
-
 variable "availability_zones" {
   type = "list"
 }


### PR DESCRIPTION
changes to allow storage of state in an s3 bucket, plus an example recommended configuration that uses a wrapper template that contains template and backend configuration information. This can be checked into git to help allow for day 2 operations.