### PR TITLE
EIP, ENI, subnet placements

### DIFF
--- a/env/dev/ssh/main.tf
+++ b/env/dev/ssh/main.tf
@@ -39,6 +39,8 @@ module "pas" {
   vpc_id                = "${local.vpc_id}"
   ops_manager_role_name = "DIRECTOR"
   ops_manager_ami       = "ami-0b4e720c1858f1786"
+  om_eip                = true
+  om_eni                = true
 }
 
 module "igw" {

--- a/env/dev/vgw/main.tf
+++ b/env/dev/vgw/main.tf
@@ -42,7 +42,8 @@ module "pas" {
   internetless          = true
   ops_manager_private   = false
   om_eip                = false
-  om_eni                = false
+  om_eni                = true
+  om_public_subnet      = true
 }
 
 module "vgw" {

--- a/env/dev/vgw/main.tf
+++ b/env/dev/vgw/main.tf
@@ -40,6 +40,9 @@ module "pas" {
   ops_manager_role_name = "DIRECTOR"
   ops_manager_ami       = "ami-0b4e720c1858f1786"
   internetless          = true
+  ops_manager_private   = false
+  om_eip                = false
+  om_eni                = false
 }
 
 module "vgw" {

--- a/modules/ops_manager/eip.tf
+++ b/modules/ops_manager/eip.tf
@@ -1,13 +1,13 @@
 resource "aws_eip" "ops_manager_attached" {
   instance = "${aws_instance.ops_manager.id}"
-  count    = "${var.private ? 0 : var.vm_count}"
+  count    = "${var.om_eip ? var.vm_count : 0}"
   vpc      = true
 
   tags = "${merge(var.tags, map("Name", "${var.env_name}-om-eip"))}"
 }
 
 resource "aws_eip" "ops_manager_unattached" {
-  count = "${var.private || (var.vm_count > 0) ? 0 : 1}"
+  count    = "${var.vm_count > 0 ? 0 : var.om_eip}"
   vpc   = true
 
   tags = "${merge(var.tags, map("Name", "${var.env_name}-om-eip"))}"
@@ -15,7 +15,7 @@ resource "aws_eip" "ops_manager_unattached" {
 
 resource "aws_eip" "optional_ops_manager" {
   instance = "${aws_instance.optional_ops_manager.id}"
-  count    = "${var.private ? 0 : var.optional_count}"
+  count    = "${var.om_eip ? var.optional_count: 0}"
   vpc      = true
 
   tags = "${merge(var.tags, map("Name", "${var.env_name}-optional-om-eip"))}"

--- a/modules/ops_manager/eni.tf
+++ b/modules/ops_manager/eni.tf
@@ -1,0 +1,30 @@
+resource "aws_network_interface" "ops_manager_attached" {
+  subnet_id = "${var.subnet_id}"
+  count     = "${var.om_eni ? var.vm_count : 0}"
+
+  attachment {
+    device_index = 1
+    instance = "${aws_instance.ops_manager.id}"
+  }
+
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-om-eni"))}"
+}
+
+resource "aws_network_interface" "ops_manager_unattached" {
+  subnet_id = "${var.subnet_id}"
+  count    = "${var.vm_count > 0 ? 0 : var.om_eni}"
+
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-om-eni"))}"
+}
+
+resource "aws_network_interface" "optional_ops_manager" {
+  subnet_id = "${var.subnet_id}"
+  count    = "${var.om_eni ? var.optional_count: 0}"
+
+  attachment {
+    device_index = 0
+    instance = "${aws_instance.optional_ops_manager.id}"
+  }
+
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-optional-om-eni"))}"
+}

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -1,5 +1,9 @@
 variable "optional_count" {}
 
+variable "om_eip" {}
+
+variable "om_eni" {}
+
 variable "vm_count" {}
 
 variable "private" {}

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -50,6 +50,8 @@ module "ops_manager" {
   additional_iam_roles_arn = ["${module.pas.iam_pas_bucket_role_arn}"]
   bucket_suffix            = "${local.bucket_suffix}"
   ops_manager_role_name    = "${var.ops_manager_role_name}"
+  om_eni                   = "${var.om_eni}"
+  om_eip                   = "${var.om_eip}"
 
   tags = "${local.actual_tags}"
   use_route53 = "${var.use_route53}"

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -1,5 +1,5 @@
 locals {
-  ops_man_subnet_id = "${var.ops_manager_private ? element(module.infra.infrastructure_subnet_ids, 0) : element(module.infra.public_subnet_ids, 0)}"
+  ops_man_subnet_id = "${var.om_public_subnet ? element(module.infra.public_subnet_ids, 0) : element(module.infra.infrastructure_subnet_ids, 0)}"
 
   bucket_suffix = "${random_integer.bucket.result}"
 

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -1,5 +1,15 @@
 variable "env_name" {}
 
+variable "om_eip" {
+  default = true
+  description = "Creates an EIP for OM"
+}
+
+variable "om_eni" {
+  default = false
+  description = "Creates an ENI for OM"
+}
+
 variable "use_tcp_routes" {
   default = true
   description = "Indicate whether or not to enable tcp routes and elbs"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -10,6 +10,12 @@ variable "om_eni" {
   description = "Creates an ENI for OM"
 }
 
+variable "om_public_subnet" {
+  default = true
+  description = "if true puts the OM instance in the public subnet. If false, puts it in the infra subnet."
+}
+
+
 variable "use_tcp_routes" {
   default = true
   description = "Indicate whether or not to enable tcp routes and elbs"


### PR DESCRIPTION
there was a bunch of interconnected logic in the templates to control where OM landed, if it was given an EIP or not, security group configuration, etc. We spit this out and can now control it via additional flags, plus updated the example templates to show how to control how TF works for commercial and air gapped systems.